### PR TITLE
feat: SD-524 grafica schedule dashboard

### DIFF
--- a/src/app/components/dashboard1/weekly-hours/weekly-hours.component.ts
+++ b/src/app/components/dashboard1/weekly-hours/weekly-hours.component.ts
@@ -161,8 +161,9 @@ export class AppWeeklyHoursComponent implements OnInit {
     const currentDay = moment().tz(this.companyTimezone).format('ddd');
     const gray = '#e7ecf0';
     const green = 'var(--mat-sys-primary)';
+    const lightGreen = '#bdd99b'; 
     const workedColors = days.map(day => (day === currentDay ? green : gray));
-    const notWorkedColors = days.map(() => gray);
+    const notWorkedColors = days.map(day => (day === currentDay ? lightGreen : gray));
 
     this.paymentsChart.colors = [
       ({ dataPointIndex, seriesIndex }: any) => {


### PR DESCRIPTION
The current day is now highlighted with a soft green color in the schedule chart. The hours worked are highlighted with a darker green (primary color).